### PR TITLE
Update keyboard.js to solve modifier state bug

### DIFF
--- a/content/javascripts/keyboard.js
+++ b/content/javascripts/keyboard.js
@@ -79,6 +79,8 @@
             // Register key events
             $(document).on("keydown", null, $.proxy(this._keyDown, this));
             $(document).on("keyup", null, $.proxy(this._keyUp, this));
+            this._clearActiveModifiers();
+            this._update();
         },
 
         _keyDown: function(e) {


### PR DESCRIPTION
Fix a bug. 

How to generate the bug: 

1. open http://waldobronchart.github.io/ShortcutMapper/
2. use mouse to click the Ctrl key on the page, the Ctrl key activated. 
3. Switch to other apps or other keyboard layout or other system. 

Behavior: The Ctrl modifier key `"mod-active"` class has been reset, but the `this.activeModKeys` hasn't been clear. 

How to fix: clear the `this.activeModKeys` every time a new keyboard is generated. 